### PR TITLE
Update config.php to support matomo 4

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -1,5 +1,5 @@
 <?php
 
 return array(
-    'Piwik\Translation\Loader\JsonFileLoader' => DI\object('Piwik\Plugins\CustomiseTranslations\MyCustomLoader'),
+    'Piwik\Translation\Loader\JsonFileLoader' => DI\autowire('Piwik\Plugins\CustomiseTranslations\MyCustomLoader'),
 );


### PR DESCRIPTION
matomo 4 now uses php-di v6 upward and DI/object is deprecated in favaour of DI\autowire or create.
